### PR TITLE
Parallelized Node RPC Calls for Health Checking

### DIFF
--- a/internal/api/service/health.go
+++ b/internal/api/service/health.go
@@ -1,29 +1,44 @@
 package service
 
 import (
+	"sync"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/base-org/pessimism/internal/api/models"
 	"github.com/base-org/pessimism/internal/client"
 	"github.com/base-org/pessimism/internal/core"
 	"github.com/base-org/pessimism/internal/logging"
-
-	"go.uber.org/zap"
 )
 
 // CheckHealth ... Returns health check for server
 func (svc *PessimismService) CheckHealth() *models.HealthCheck {
-	// TODO(#88): Parallelized Node Queries for Health Checking
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
 	hc := &models.ChainConnectionStatus{
-		IsL1Healthy: svc.CheckETHRPCHealth(core.Layer1),
-		IsL2Healthy: svc.CheckETHRPCHealth(core.Layer2),
+		IsL1Healthy: false,
+		IsL2Healthy: false,
 	}
 
-	healthy := hc.IsL1Healthy && hc.IsL2Healthy
+	go func() {
+		defer wg.Done()
+
+		hc.IsL1Healthy = svc.CheckETHRPCHealth(core.Layer1)
+	}()
+
+	go func() {
+		defer wg.Done()
+		hc.IsL2Healthy = svc.CheckETHRPCHealth(core.Layer2)
+	}()
+
+	wg.Wait()
 
 	return &models.HealthCheck{
 		Timestamp:             time.Now(),
-		Healthy:               healthy,
+		Healthy:               hc.IsL1Healthy && hc.IsL2Healthy,
 		ChainConnectionStatus: hc,
 	}
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes 88

<!-- Example: Closes #NNN -->
Fixes https://github.com/base-org/pessimism/issues/88
## Changes proposed

 I have migrated the health checks to make use of `sync.WaitGroup`. this allows both checks for the L1 and L2 to be run concurrently instead of sequentially.

### Screenshots (Optional)

## Note to reviewers
