### PR TITLE
Concurrent Heuristic Execution

### DIFF
--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -90,8 +90,6 @@ func CreateL2TestSuite(t *testing.T) *L2TestSuite {
 
 	pagerdutyServer := NewTestPagerDutyServer("127.0.0.1", 0)
 
-	appCfg.AlertConfig.RoutingCfgPath = ""
-
 	slackURL := fmt.Sprintf("http://127.0.0.1:%d", slackServer.Port)
 	pagerdutyURL := fmt.Sprintf("http://127.0.0.1:%d", pagerdutyServer.Port)
 
@@ -169,8 +167,6 @@ func CreateSysTestSuite(t *testing.T) *SysTestSuite {
 	slackServer := NewTestSlackServer("127.0.0.1", 0)
 
 	pagerdutyServer := NewTestPagerDutyServer("127.0.0.1", 0)
-
-	appCfg.AlertConfig.RoutingCfgPath = ""
 
 	slackURL := fmt.Sprintf("http://127.0.0.1:%d", slackServer.Port)
 	pagerdutyURL := fmt.Sprintf("http://127.0.0.1:%d", pagerdutyServer.Port)

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/base-org/pessimism/internal/client"
 	"github.com/base-org/pessimism/internal/config"
 	"github.com/base-org/pessimism/internal/core"
+	"github.com/base-org/pessimism/internal/engine"
 	"github.com/base-org/pessimism/internal/logging"
 	"github.com/base-org/pessimism/internal/metrics"
 	"github.com/base-org/pessimism/internal/state"
@@ -210,14 +211,17 @@ func DefaultTestConfig() *config.Config {
 	l1PollInterval := 900
 	l2PollInterval := 300
 	maxPipelines := 10
+	workerCount := 4
 
 	return &config.Config{
 		Environment:   core.Development,
 		BootStrapPath: "",
-		SystemConfig: &subsystem.Config{
-			MaxPipelineCount: maxPipelines,
-			L2PollInterval:   l2PollInterval,
-			L1PollInterval:   l1PollInterval,
+		AlertConfig: &alert.Config{
+			PagerdutyAlertEventsURL: "",
+			RoutingCfgPath:          "",
+		},
+		EngineConfig: &engine.Config{
+			WorkerCount: workerCount,
 		},
 		MetricsConfig: &metrics.Config{
 			Enabled: false,
@@ -228,9 +232,10 @@ func DefaultTestConfig() *config.Config {
 			Host: "localhost",
 			Port: 0,
 		},
-		AlertConfig: &alert.Config{
-			PagerdutyAlertEventsURL: "",
-			RoutingCfgPath:          "",
+		SystemConfig: &subsystem.Config{
+			MaxPipelineCount: maxPipelines,
+			L2PollInterval:   l2PollInterval,
+			L1PollInterval:   l1PollInterval,
 		},
 	}
 }

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -87,13 +87,13 @@ func InitializeETL(ctx context.Context, transit chan core.HeuristicInput) pipeli
 }
 
 // InitializeEngine ... Performs dependency injection to build engine struct
-func InitializeEngine(ctx context.Context, transit chan core.Alert) engine.Manager {
+func InitializeEngine(ctx context.Context, cfg *config.Config, transit chan core.Alert) engine.Manager {
 	store := engine.NewSessionStore()
 	am := engine.NewAddressingMap()
 	re := engine.NewHardCodedEngine(transit)
 	it := e_registry.NewHeuristicTable()
 
-	return engine.NewManager(ctx, re, am, store, it, transit)
+	return engine.NewManager(ctx, cfg.EngineConfig, re, am, store, it, transit)
 }
 
 // NewPessimismApp ... Performs dependency injection to build app struct
@@ -108,7 +108,7 @@ func NewPessimismApp(ctx context.Context, cfg *config.Config) (*Application, fun
 		return nil, nil, err
 	}
 
-	engine := InitializeEngine(ctx, alerting.Transit())
+	engine := InitializeEngine(ctx, cfg, alerting.Transit())
 	etl := InitializeETL(ctx, engine.Transit())
 
 	m := subsystem.NewManager(ctx, cfg.SystemConfig, etl, engine, alerting)

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -90,7 +90,7 @@ func InitializeETL(ctx context.Context, transit chan core.HeuristicInput) pipeli
 func InitializeEngine(ctx context.Context, transit chan core.Alert) engine.Manager {
 	store := engine.NewSessionStore()
 	am := engine.NewAddressingMap()
-	re := engine.NewHardCodedEngine()
+	re := engine.NewHardCodedEngine(transit)
 	it := e_registry.NewHeuristicTable()
 
 	return engine.NewManager(ctx, re, am, store, it, transit)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -77,23 +77,23 @@ type HeuristicInput struct {
 	Input TransitData
 }
 
-// EngineInputRelay ... Represents a inter-subsystem
+// ExecInputRelay ... Represents a inter-subsystem
 // relay used to bind final ETL pipeline outputs to risk engine inputs
-type EngineInputRelay struct {
+type ExecInputRelay struct {
 	pUUID   PUUID
 	outChan chan HeuristicInput
 }
 
 // NewEngineRelay ... Initializer
-func NewEngineRelay(pUUID PUUID, outChan chan HeuristicInput) *EngineInputRelay {
-	return &EngineInputRelay{
+func NewEngineRelay(pUUID PUUID, outChan chan HeuristicInput) *ExecInputRelay {
+	return &ExecInputRelay{
 		pUUID:   pUUID,
 		outChan: outChan,
 	}
 }
 
 // RelayTransitData ... Creates heuristic input from transit data to send to risk engine
-func (eir *EngineInputRelay) RelayTransitData(td TransitData) error {
+func (eir *ExecInputRelay) RelayTransitData(td TransitData) error {
 	hi := HeuristicInput{
 		PUUID: eir.pUUID,
 		Input: td,

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"time"
 
 	"github.com/base-org/pessimism/internal/core"
 	"github.com/base-org/pessimism/internal/engine/heuristic"
@@ -20,27 +21,50 @@ const (
 	Dynamic
 )
 
+// EngineInput ... Parameter wrapper for engine execution input
+type EngineInput struct {
+	ctx context.Context
+	hi  core.HeuristicInput
+	h   heuristic.Heuristic
+}
+
+// EngineOutput ... Parameter wrapper for engine execution output
+type EngineOutput struct {
+	act       *core.Activation
+	activated bool
+}
+
 // RiskEngine ... Execution engine interface
 type RiskEngine interface {
 	Type() Type
 	Execute(context.Context, core.TransitData,
 		heuristic.Heuristic) (*core.Activation, bool)
+	AddWorkerIngress(chan EngineInput)
+	EventLoop(context.Context)
 }
 
 // hardCodedEngine ... Hard coded execution engine
 // IE: native hardcoded application code for heuristic implementation
 type hardCodedEngine struct {
-	// TODO: Add any engine specific fields here
+	heuristicIn chan EngineInput
+	alertEgress chan core.Alert
 }
 
 // NewHardCodedEngine ... Initializer
-func NewHardCodedEngine() RiskEngine {
-	return &hardCodedEngine{}
+func NewHardCodedEngine(egress chan core.Alert) RiskEngine {
+	return &hardCodedEngine{
+		alertEgress: egress,
+	}
 }
 
 // Type ... Returns the engine type
 func (e *hardCodedEngine) Type() Type {
 	return HardCoded
+}
+
+// AddWorkerIngress ... Adds a worker ingress channel
+func (e *hardCodedEngine) AddWorkerIngress(ingress chan EngineInput) {
+	e.heuristicIn = ingress
 }
 
 // Execute ... Executes the heuristic
@@ -49,7 +73,7 @@ func (e *hardCodedEngine) Execute(ctx context.Context, data core.TransitData,
 	logger := logging.WithContext(ctx)
 
 	logger.Debug("Performing heuristic activation",
-		zap.String("suuid", h.SUUID().String()))
+		zap.String(logging.SUUIDKey, h.SUUID().String()))
 	outcome, activated, err := h.Assess(data)
 	if err != nil {
 		logger.Error("Failed to perform activation option for heuristic", zap.Error(err))
@@ -61,4 +85,45 @@ func (e *hardCodedEngine) Execute(ctx context.Context, data core.TransitData,
 	}
 
 	return outcome, activated
+}
+
+// EventLoop ... Event loop for the risk engine
+func (hce *hardCodedEngine) EventLoop(ctx context.Context) {
+	logger := logging.WithContext(ctx)
+
+	for {
+		select {
+		case <-ctx.Done(): // Context cancelled
+			logger.Info("Risk engine event loop cancelled")
+			return
+
+		case execInput := <-hce.heuristicIn: // Heuristic input received
+			logger.Debug("Heuristic input received",
+				zap.String(logging.SUUIDKey, execInput.h.SUUID().String()))
+
+			// (1) Execute heuristic
+			start := time.Now()
+			outcome, activated := hce.Execute(ctx, execInput.hi.Input, execInput.h)
+			metrics.WithContext(ctx).RecordHeuristicRun(execInput.h)
+			metrics.WithContext(ctx).RecordInvExecutionTime(execInput.h, float64(time.Since(start).Nanoseconds()))
+
+			// (2) Send alert if activated
+			if activated {
+				alert := core.Alert{
+					Timestamp: outcome.TimeStamp,
+					SUUID:     execInput.h.SUUID(),
+					Content:   outcome.Message,
+					PUUID:     execInput.hi.PUUID,
+					Ptype:     execInput.hi.PUUID.PipelineType(),
+				}
+
+				logger.Warn("Heuristic alert",
+					zap.String(logging.SUUIDKey, execInput.h.SUUID().String()),
+					zap.String("message", outcome.Message))
+
+				hce.alertEgress <- alert
+			}
+
+		}
+	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,17 +21,11 @@ const (
 	Dynamic
 )
 
-// EngineInput ... Parameter wrapper for engine execution input
-type EngineInput struct {
+// ExecInput ... Parameter wrapper for engine execution input
+type ExecInput struct {
 	ctx context.Context
 	hi  core.HeuristicInput
 	h   heuristic.Heuristic
-}
-
-// EngineOutput ... Parameter wrapper for engine execution output
-type EngineOutput struct {
-	act       *core.Activation
-	activated bool
 }
 
 // RiskEngine ... Execution engine interface
@@ -39,14 +33,14 @@ type RiskEngine interface {
 	Type() Type
 	Execute(context.Context, core.TransitData,
 		heuristic.Heuristic) (*core.Activation, bool)
-	AddWorkerIngress(chan EngineInput)
+	AddWorkerIngress(chan ExecInput)
 	EventLoop(context.Context)
 }
 
 // hardCodedEngine ... Hard coded execution engine
 // IE: native hardcoded application code for heuristic implementation
 type hardCodedEngine struct {
-	heuristicIn chan EngineInput
+	heuristicIn chan ExecInput
 	alertEgress chan core.Alert
 }
 
@@ -58,17 +52,17 @@ func NewHardCodedEngine(egress chan core.Alert) RiskEngine {
 }
 
 // Type ... Returns the engine type
-func (e *hardCodedEngine) Type() Type {
+func (hce *hardCodedEngine) Type() Type {
 	return HardCoded
 }
 
 // AddWorkerIngress ... Adds a worker ingress channel
-func (e *hardCodedEngine) AddWorkerIngress(ingress chan EngineInput) {
-	e.heuristicIn = ingress
+func (hce *hardCodedEngine) AddWorkerIngress(ingress chan ExecInput) {
+	hce.heuristicIn = ingress
 }
 
 // Execute ... Executes the heuristic
-func (e *hardCodedEngine) Execute(ctx context.Context, data core.TransitData,
+func (hce *hardCodedEngine) Execute(ctx context.Context, data core.TransitData,
 	h heuristic.Heuristic) (*core.Activation, bool) {
 	logger := logging.WithContext(ctx)
 
@@ -123,7 +117,6 @@ func (hce *hardCodedEngine) EventLoop(ctx context.Context) {
 
 				hce.alertEgress <- alert
 			}
-
 		}
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -23,7 +23,7 @@ func createTestSuite(t *testing.T) *testSuite {
 
 	return &testSuite{
 		ctrl:          ctrl,
-		re:            engine.NewHardCodedEngine(),
+		re:            engine.NewHardCodedEngine(make(chan core.Alert)),
 		mockHeuristic: mocks.NewMockHeuristic(ctrl),
 	}
 }

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -44,10 +44,8 @@ type engineManager struct {
 
 	// Used to receive heuristic input from ETL subsystem
 	etlIngress chan core.HeuristicInput
-
 	// Used to send alerts to alerting subsystem
 	alertEgress chan core.Alert
-
 	// Used to send execution requests to engine worker subscribers
 	workerEgress chan ExecInput
 
@@ -77,6 +75,7 @@ func NewManager(ctx context.Context, cfg *Config, engine RiskEngine, addr Addres
 	}
 
 	// Start engine worker pool for concurrent heuristic execution
+	// TODO: Add validation checks for worker count
 	for i := 0; i < cfg.WorkerCount; i++ {
 		logging.WithContext(ctx).Debug("Starting engine worker routine", zap.Int("worker", i))
 

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -5,7 +5,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/base-org/pessimism/internal/core"
 	"github.com/base-org/pessimism/internal/engine/heuristic"
@@ -39,8 +38,14 @@ type engineManager struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	etlIngress    chan core.HeuristicInput
-	alertOutgress chan core.Alert
+	// Used to receive heuristic input from ETL subsystem
+	etlIngress chan core.HeuristicInput
+
+	// Used to send alerts to alerting subsystem
+	alertEgress chan core.Alert
+
+	// Used to send execution requests to engine worker subscribers
+	workerEgress chan EngineInput
 
 	metrics    metrics.Metricer
 	engine     RiskEngine
@@ -51,19 +56,31 @@ type engineManager struct {
 
 // NewManager ... Initializer
 func NewManager(ctx context.Context, engine RiskEngine, addr AddressingMap,
-	store SessionStore, it registry.HeuristicTable, alertOutgress chan core.Alert) Manager {
+	store SessionStore, it registry.HeuristicTable, alertEgress chan core.Alert) Manager {
 	ctx, cancel := context.WithCancel(ctx)
 
 	em := &engineManager{
-		ctx:           ctx,
-		cancel:        cancel,
-		alertOutgress: alertOutgress,
-		etlIngress:    make(chan core.HeuristicInput),
-		engine:        engine,
-		addresser:     addr,
-		store:         store,
-		heuristics:    it,
-		metrics:       metrics.WithContext(ctx),
+		ctx:          ctx,
+		cancel:       cancel,
+		alertEgress:  alertEgress,
+		etlIngress:   make(chan core.HeuristicInput),
+		workerEgress: make(chan EngineInput),
+		engine:       engine,
+		addresser:    addr,
+		store:        store,
+		heuristics:   it,
+		metrics:      metrics.WithContext(ctx),
+	}
+
+	// TODO - Make this configurable
+	count := 4
+
+	// Start engine worker pool for concurrent heuristic execution
+	for i := 0; i < count; i++ {
+		logging.WithContext(ctx).Debug("Starting engine worker routine", zap.Int("worker", i))
+
+		engine.AddWorkerIngress(em.workerEgress)
+		go engine.EventLoop(ctx)
 	}
 
 	return em
@@ -231,7 +248,7 @@ func (em *engineManager) executeAddressHeuristics(ctx context.Context, data core
 	for _, sUUID := range ids {
 		h, err := em.store.GetInstanceByUUID(sUUID)
 		if err != nil {
-			logger.Error("Could not session by heuristic sUUID",
+			logger.Error("Could not find session by heuristic sUUID",
 				zap.Error(err),
 				zap.String(logging.PUUIDKey, sUUID.String()))
 			continue
@@ -266,31 +283,14 @@ func (em *engineManager) executeNonAddressHeuristics(ctx context.Context, data c
 	}
 }
 
-// executeHeuristic ... Executes a single heuristic using the risk engine
+// executeHeuristic ... Sends heuristic input to engine worker pool for execution
 func (em *engineManager) executeHeuristic(ctx context.Context, data core.HeuristicInput, h heuristic.Heuristic) {
-	logger := logging.WithContext(ctx)
-
-	start := time.Now()
-	// Execute heuristic using risk engine and return alert if activation occurs
-	outcome, activated := em.engine.Execute(ctx, data.Input, h)
-
-	em.metrics.RecordHeuristicRun(h)
-	em.metrics.RecordInvExecutionTime(h, float64(time.Since(start).Nanoseconds()))
-
-	if activated {
-		// Generate & send alert
-		alert := core.Alert{
-			Timestamp: outcome.TimeStamp,
-			SUUID:     h.SUUID(),
-			Content:   outcome.Message,
-			PUUID:     data.PUUID,
-			Ptype:     data.PUUID.PipelineType(),
-		}
-
-		logger.Warn("Heuristic alert",
-			zap.String(logging.SUUIDKey, h.SUUID().String()),
-			zap.String("message", outcome.Message))
-
-		em.alertOutgress <- alert
+	ei := EngineInput{
+		ctx: ctx,
+		hi:  data,
+		h:   h,
 	}
+
+	// Send heuristic input to engine worker pool
+	em.workerEgress <- ei
 }

--- a/internal/engine/manager_test.go
+++ b/internal/engine/manager_test.go
@@ -26,7 +26,8 @@ func Test_EventLoop(t *testing.T) {
 	ctx = context.WithValue(ctx, core.State, ss)
 
 	em := engine.NewManager(ctx,
-		engine.NewHardCodedEngine(make(chan core.Alert)),
+		&engine.Config{WorkerCount: 1},
+		engine.NewHardCodedEngine(alertChan),
 		engine.NewAddressingMap(),
 		engine.NewSessionStore(),
 		registry.NewHeuristicTable(),

--- a/internal/engine/manager_test.go
+++ b/internal/engine/manager_test.go
@@ -26,7 +26,7 @@ func Test_EventLoop(t *testing.T) {
 	ctx = context.WithValue(ctx, core.State, ss)
 
 	em := engine.NewManager(ctx,
-		engine.NewHardCodedEngine(),
+		engine.NewHardCodedEngine(make(chan core.Alert)),
 		engine.NewAddressingMap(),
 		engine.NewSessionStore(),
 		registry.NewHeuristicTable(),

--- a/internal/etl/component/component.go
+++ b/internal/etl/component/component.go
@@ -28,7 +28,7 @@ type Component interface {
 	Type() core.ComponentType
 
 	// AddRelay ... Adds an engine relay to component egress routing
-	AddRelay(relay *core.EngineInputRelay) error
+	AddRelay(relay *core.ExecInputRelay) error
 
 	// AddEgress ...
 	AddEgress(core.CUUID, chan core.TransitData) error

--- a/internal/etl/component/egress.go
+++ b/internal/etl/component/egress.go
@@ -11,7 +11,7 @@ import (
 type egressHandler struct {
 	egresses map[core.ComponentPID]chan core.TransitData
 
-	relay *core.EngineInputRelay
+	relay *core.ExecInputRelay
 }
 
 // newEgress ... Initializer
@@ -87,7 +87,7 @@ func (eh *egressHandler) HasEngineRelay() bool {
 }
 
 // AddRelay ... Adds a relay assuming no existing ones
-func (eh *egressHandler) AddRelay(relay *core.EngineInputRelay) error {
+func (eh *egressHandler) AddRelay(relay *core.ExecInputRelay) error {
 	if eh.HasEngineRelay() {
 		return fmt.Errorf(engineEgressExistsErr)
 	}


### PR DESCRIPTION
# Concurrent Heuristic Execution

## Changes proposed
* Added support for concurrent heuristic execution using subscriber channel go routines that await `EngineInput` 
* Added a `ENGINE_WORKER_COUNT` env var that defines how many routines should be ran for heuristic processing
* Updated tests and documentation

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
