### PR TITLE
[WIP]Change alert manager's 'Transit' method to 'Ingress'

### DIFF
--- a/internal/alert/manager.go
+++ b/internal/alert/manager.go
@@ -17,7 +17,7 @@ import (
 // Manager ... Interface for alert manager
 type Manager interface {
 	AddSession(core.UUID, *core.AlertPolicy) error
-	Transit() chan core.Alert
+	Ingress() chan core.Alert
 
 	core.Subsystem
 }
@@ -76,9 +76,8 @@ func (am *alertManager) AddSession(id core.UUID, policy *core.AlertPolicy) error
 	return am.store.AddAlertPolicy(id, policy)
 }
 
-// Transit ... Returns inter-subsystem transit channel for receiving alerts
-// TODO - Rename this to ingress()
-func (am *alertManager) Transit() chan core.Alert {
+// Ingress ... Returns inter-subsystem transit channel for receiving alerts
+func (am *alertManager) Ingress() chan core.Alert {
 	return am.alertTransit
 }
 

--- a/internal/alert/manager_test.go
+++ b/internal/alert/manager_test.go
@@ -53,7 +53,7 @@ func TestEventLoop(t *testing.T) {
 					_ = am.Shutdown()
 				}()
 
-				ingress := am.Transit()
+				ingress := am.Ingress()
 
 				cm.SetSNSClient(sns)
 				cm.SetSlackClients([]client.SlackClient{mocks.NewMockSlackClient(c)}, core.LOW)
@@ -117,7 +117,7 @@ func TestEventLoop(t *testing.T) {
 					_ = am.Shutdown()
 				}()
 
-				ingress := am.Transit()
+				ingress := am.Ingress()
 
 				cm.SetPagerDutyClients([]client.PagerDutyClient{mocks.NewMockPagerDutyClient(c)}, core.MEDIUM)
 				cm.SetSNSClient(sns)
@@ -181,7 +181,7 @@ func TestEventLoop(t *testing.T) {
 					_ = am.Shutdown()
 				}()
 
-				ingress := am.Transit()
+				ingress := am.Ingress()
 
 				cm.SetSlackClients([]client.SlackClient{mocks.NewMockSlackClient(c), mocks.NewMockSlackClient(c)}, core.HIGH)
 				cm.SetPagerDutyClients([]client.PagerDutyClient{mocks.NewMockPagerDutyClient(c), mocks.NewMockPagerDutyClient(c)}, core.HIGH)


### PR DESCRIPTION
# Pull Request Template

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed
Simply changing the `Transit` method to `Ingress` as per the to-do
<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
